### PR TITLE
Feature/onboarding: artistItem에 백엔드 api에서 받아온 이미지 표시

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,4 @@
 import 'package:birca/view/login/login.dart';
-import 'package:birca/viewModel/businessLicenseViewModel.dart';
 import 'package:birca/viewmodel/select_favorite_artist_viewmodel.dart';
 import 'package:birca/viewmodel/select_interest_artist_viewmodel.dart';
 import 'package:birca/viewModel/business_license_view_model.dart';

--- a/lib/view/onboarding/onboarding_visitor_complete.dart
+++ b/lib/view/onboarding/onboarding_visitor_complete.dart
@@ -78,10 +78,11 @@ class OnboardingVisitorComplete extends StatelessWidget {
               textColor: Colors.white,
               fontWeight: FontWeight.normal,
               onPressed: () {
-                Navigator.push(
-                    context,
-                    MaterialPageRoute(
-                        builder: (context) => const BottomNavVisitor()));
+                Navigator.pushAndRemoveUntil(
+                  context,
+                  MaterialPageRoute(builder: (context) => const BottomNavVisitor()),
+                      (Route<dynamic> route) => false,
+                );
               },
             ),
           )

--- a/lib/view/onboarding/select_favorite_artist_screen.dart
+++ b/lib/view/onboarding/select_favorite_artist_screen.dart
@@ -11,6 +11,7 @@ import '../../viewmodel/select_favorite_artist_viewmodel.dart';
 import '../../widgets/button.dart';
 import '../../widgets/card.dart';
 import '../../widgets/progressbar.dart';
+import 'onboarding_visitor_complete.dart';
 
 class SelectFavoriteArtistScreen extends StatefulWidget {
   const SelectFavoriteArtistScreen({super.key});
@@ -184,21 +185,31 @@ class SelectFavoriteArtistScreenState
                     child: CustomPaint(
                       painter: BubblePainter(idx: location),
                       child: Container(
-                        padding: const EdgeInsets.only(left: 20),
-                        child: Consumer<SelectFavoriteArtistViewModel>(
-                          builder: (context, model, _) => ListView(
-                            scrollDirection: Axis.horizontal,
-                            children: List.generate(model.groupMemberCount, (index) =>
-                              GestureDetector(
-                                onTap: () {
-                                  model.updateSelectedArtist(model.groupMember![index]);
-                                },
-                                child: artistItem('lib/assets/image/artist.svg', model.groupMember![index].groupName),
-                              ),
-                            ),
-                          )
-                        )
-                      ),
+                          padding: const EdgeInsets.only(left: 20, right: 20),
+                          child: Consumer<SelectFavoriteArtistViewModel>(
+                              builder: (context, model, _) =>
+                                  ListView.separated(
+                                    scrollDirection: Axis.horizontal,
+                                    itemCount: model.groupMemberCount,
+                                    separatorBuilder:
+                                        (BuildContext context, int index) {
+                                      return const SizedBox(
+                                          width: 20); // 각 아이템 사이의 간격 설정
+                                    },
+                                    itemBuilder:
+                                        (BuildContext context, int index) {
+                                      return GestureDetector(
+                                        onTap: () {
+                                          model.updateSelectedArtist(
+                                              model.groupMember![index]);
+                                        },
+                                        child: artistItem(
+                                          model.groupMember![index].groupImage,
+                                          model.groupMember![index].groupName,
+                                        ),
+                                      );
+                                    },
+                                  ))),
                     ),
                   ),
                 )
@@ -220,23 +231,25 @@ class SelectFavoriteArtistScreenState
                   child: _groupArtistItem(index, itemIndex + 1),
                 )));
 
-  _groupArtistItem(int index, int location) => Consumer<SelectFavoriteArtistViewModel>(
-      builder: (context, model, _) => GestureDetector(
-            onTap: () {
-              model.getGroupMember(model.groupArtist![(index * 4 + location) - 1].groupId);
-              log("test: ${model.getGroupMember(model.groupArtist![(index * 4 + location) - 1].groupId)}");
-              setState(() {
-                if (expandedIndex == index) {
-                  expandedIndex = -1;
-                } else {
-                  expandedIndex = index;
-                  this.location = location;
-                }
-              });
-            },
-            child: artistItem('lib/assets/image/artist.svg',
-                model.groupArtist![(index * 4 + location) - 1].groupName),
-          ));
+  _groupArtistItem(int index, int location) =>
+      Consumer<SelectFavoriteArtistViewModel>(
+          builder: (context, model, _) => GestureDetector(
+                onTap: () {
+                  model.getGroupMember(
+                      model.groupArtist![(index * 4 + location) - 1].groupId);
+                  setState(() {
+                    if (expandedIndex == index) {
+                      expandedIndex = -1;
+                    } else {
+                      expandedIndex = index;
+                      this.location = location;
+                    }
+                  });
+                },
+                child: artistItem(
+                    model.groupArtist![(index * 4 + location) - 1].groupImage,
+                    model.groupArtist![(index * 4 + location) - 1].groupName),
+              ));
 
   _soloArtistBuilder() => Consumer<SelectFavoriteArtistViewModel>(
         builder: (context, model, _) => GridView.builder(
@@ -252,7 +265,7 @@ class SelectFavoriteArtistScreenState
               onTap: () {
                 model.updateSelectedArtist(model.soloArtist![index]);
               },
-              child: artistItem('lib/assets/image/artist.svg',
+              child: artistItem(model.soloArtist![index].groupImage,
                   model.soloArtist![index].groupName),
             );
           },
@@ -261,37 +274,42 @@ class SelectFavoriteArtistScreenState
 
   _bottomBar() => Consumer<SelectFavoriteArtistViewModel>(
       builder: (context, model, _) => Container(
-            color: Colors.white,
-            width: double.infinity,
-            child: Column(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: [
-                _selectedArtist(),
-                Container(
-                    width: double.infinity,
-                    height: 46,
-                    margin: const EdgeInsets.symmetric(horizontal: 30),
-                    child: BircaElevatedButton(
-                      text: "최애 아티스트 결정하기",
-                      color: (model.selectedArtist.isEmpty)
-                          ? Palette.gray04
-                          : Palette.primary,
-                      fontSize: 18,
-                      textColor: Colors.white,
-                      fontWeight: FontWeight.w500,
-                      onPressed: () {
-                        if(model.selectedArtist.isNotEmpty) {
-                          model.postFavoriteArtist();
-                          Navigator.push(
-                              context,
-                              MaterialPageRoute(
-                                  builder: (context) =>
-                                  const SelectInterestArtistScreen()));
-                        }
-                      },
-                    )),
-                const SizedBox(height: 20),
-                const Text(
+          color: Colors.white,
+          width: double.infinity,
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              _selectedArtist(),
+              Container(
+                  width: double.infinity,
+                  height: 46,
+                  margin: const EdgeInsets.symmetric(horizontal: 30),
+                  child: BircaElevatedButton(
+                    text: "최애 아티스트 결정하기",
+                    color: (model.selectedArtist.isEmpty)
+                        ? Palette.gray04
+                        : Palette.primary,
+                    fontSize: 18,
+                    textColor: Colors.white,
+                    fontWeight: FontWeight.w500,
+                    onPressed: () {
+                      if (model.selectedArtist.isNotEmpty) {
+                        model.postFavoriteArtist();
+                        Navigator.push(
+                            context,
+                            MaterialPageRoute(
+                                builder: (context) =>
+                                    const SelectInterestArtistScreen()));
+                      }
+                    },
+                  )),
+              const SizedBox(height: 20),
+              GestureDetector(
+                onTap: () {
+                  MaterialPageRoute(
+                      builder: (context) => const SelectInterestArtistScreen());
+                },
+                child: const Text(
                   "다음에 결정하기",
                   style: TextStyle(
                     color: Palette.gray06,
@@ -300,10 +318,10 @@ class SelectFavoriteArtistScreenState
                     decorationColor: Palette.gray06,
                   ),
                 ),
-                const SizedBox(height: 66),
-              ],
-            ),
-          ));
+              ),
+              const SizedBox(height: 66),
+            ],
+          )));
 
   _selectedArtist() => Consumer<SelectFavoriteArtistViewModel>(
       builder: (context, model, _) => Container(
@@ -322,7 +340,8 @@ class SelectFavoriteArtistScreenState
                             model.removeSelectedArtist(
                                 model.selectedArtist[index]);
                           },
-                          child: artistItem('lib/assets/image/artist.svg',
+                          child: artistItem(
+                              model.selectedArtist[index].groupImage,
                               model.selectedArtist[index].groupName),
                         ));
                   },

--- a/lib/view/onboarding/select_interest_artist_screen.dart
+++ b/lib/view/onboarding/select_interest_artist_screen.dart
@@ -10,6 +10,7 @@ import '../../designSystem/palette.dart';
 import '../../widgets/button.dart';
 import '../../widgets/card.dart';
 import '../../widgets/progressbar.dart';
+import 'onboarding_visitor_complete.dart';
 
 class SelectInterestArtistScreen extends StatefulWidget {
   const SelectInterestArtistScreen({super.key});
@@ -35,12 +36,12 @@ class SelectInterestArtistScreenState
             margin: const EdgeInsets.symmetric(horizontal: 30),
             width: double.infinity,
             height: 6,
-            child: progressBar(2 / 3)),
+            child: progressBar(3 / 3)),
         const SizedBox(height: 10),
         const Row(
           children: [
             Expanded(child: SizedBox()),
-            Text("2/3"),
+            Text("3/3"),
             SizedBox(
               width: 30,
             )
@@ -71,7 +72,7 @@ class SelectInterestArtistScreenState
         Container(
             margin: const EdgeInsets.only(left: 30),
             child: const Text(
-              "* 관심 아티스트는 10명 선택할 수 있어요",
+              "* 관심 아티스트는 10명까지 선택할 수 있어요",
               style: TextStyle(
                   color: Palette.gray06,
                   fontFamily: 'Pretendard',
@@ -192,7 +193,7 @@ class SelectInterestArtistScreenState
                                 onTap: () {
                                   model.updateSelectedArtist(model.groupMember![index]);
                                 },
-                                child: artistItem('lib/assets/image/artist.svg', model.groupMember![index].groupName),
+                                child: artistItem(model.groupMember![index].groupImage, model.groupMember![index].groupName),
                               ),
                             ),
                           )
@@ -233,7 +234,7 @@ class SelectInterestArtistScreenState
                 }
               });
             },
-            child: artistItem('lib/assets/image/artist.svg',
+            child: artistItem(model.groupArtist![(index * 4 + location) - 1].groupImage,
                 model.groupArtist![(index * 4 + location) - 1].groupName),
           ));
 
@@ -251,7 +252,7 @@ class SelectInterestArtistScreenState
               onTap: () {
                 model.updateSelectedArtist(model.soloArtist![index]);
               },
-              child: artistItem('lib/assets/image/artist.svg',
+              child: artistItem(model.soloArtist![index].groupImage,
                   model.soloArtist![index].groupName),
             );
           },
@@ -281,17 +282,29 @@ class SelectInterestArtistScreenState
                       onPressed: () {
                         if(model.selectedArtist.isNotEmpty) {
                           model.postInterestArtist();
+                          Navigator.push(
+                              context,
+                              MaterialPageRoute(
+                                  builder: (context) =>
+                                  const OnboardingVisitorComplete()));
                         }
                       },
                     )),
                 const SizedBox(height: 20),
-                const Text(
-                  "다음에 결정하기",
-                  style: TextStyle(
-                    color: Palette.gray06,
-                    fontFamily: 'Pretendard',
-                    decoration: TextDecoration.underline,
-                    decorationColor: Palette.gray06,
+                GestureDetector(
+                  onTap: () {
+                    MaterialPageRoute(
+                        builder: (context) =>
+                        const OnboardingVisitorComplete());
+                  },
+                  child: const Text(
+                    "다음에 결정하기",
+                    style: TextStyle(
+                      color: Palette.gray06,
+                      fontFamily: 'Pretendard',
+                      decoration: TextDecoration.underline,
+                      decorationColor: Palette.gray06,
+                    ),
                   ),
                 ),
                 const SizedBox(height: 66),
@@ -316,7 +329,7 @@ class SelectInterestArtistScreenState
                             model.removeSelectedArtist(
                                 model.selectedArtist[index]);
                           },
-                          child: artistItem('lib/assets/image/artist.svg',
+                          child: artistItem(model.selectedArtist[index].groupImage,
                               model.selectedArtist[index].groupName),
                         ));
                   },

--- a/lib/widgets/item.dart
+++ b/lib/widgets/item.dart
@@ -3,10 +3,24 @@ import 'package:flutter_svg/flutter_svg.dart';
 
 import '../designSystem/palette.dart';
 
-Widget artistItem(String path, String artistName) => Column(
+artistItem(String path, String artistName) => Column(
       mainAxisAlignment: MainAxisAlignment.center,
       children: [
-        SvgPicture.asset(path),
+        SizedBox(
+          height: 70,
+          width: 70,
+          child: ClipRRect(
+            borderRadius: BorderRadius.circular(50),
+            child: Image.network(
+              path,
+              fit: BoxFit.cover,
+              errorBuilder: (BuildContext context, Object exception, StackTrace? stackTrace) {
+                return Image.asset('lib/assets/image/artist.svg');
+              },
+            ),
+          ),
+        ),
+        const SizedBox(height: 6,),
         Text(
           artistName,
           style: const TextStyle(color: Palette.gray06),


### PR DESCRIPTION
## 🔎 What type of PR is this? (check all applicable)
- [x] Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Optimization
- [ ] Documentation Update
- [ ] Other... Please describe:

## 🐥 What need this change? 
- Related Issues : #17 


## 📝 Changes 
* artist item에 백엔드에서 받아온 이미지 url이 표시되도록 설정해주었습니다.
* artist item의 이미지에 boxfit 적용
* 이미지가 영역에 맞추어 확대되어 표시되도록 구현 (비율 수정x)
* 온보딩이 완료되고 홈화면으로 넘어가기 전 완료 버튼을 누르면 온보딩 과정에서 쌓인 백스텍을 모두 제거

## 📷 Screenshots, Recordings (optional)
![IMG_8D3B0E147218-1](https://github.com/BirthdayCafe/Birca/assets/63611804/0a8cbdf6-dd6c-477c-ad6d-34f4432ccfe8)


## 👫 To Reviewers (optional)
